### PR TITLE
Gateway simulation

### DIFF
--- a/src/api/calculateReported.spec.ts
+++ b/src/api/calculateReported.spec.ts
@@ -1,4 +1,4 @@
-import { calculateReported } from 'api/updateGateway.js'
+import { calculateReported } from 'api/calculateReported.js'
 
 describe('calculateReported()', () => {
 	it('should calculate the updated reported shadow', () =>

--- a/src/api/calculateReported.spec.ts
+++ b/src/api/calculateReported.spec.ts
@@ -1,0 +1,132 @@
+import { calculateReported } from 'api/updateGateway.js'
+
+describe('calculateReported()', () => {
+	it('should calculate the updated reported shadow', () =>
+		expect(
+			calculateReported({
+				robots: {
+					'00:25:96:FF:FE:12:34:51': {
+						angleDeg: 1,
+						driveTimeMs: 2,
+					},
+					'00:25:96:FF:FE:12:34:52': {
+						angleDeg: 2,
+						driveTimeMs: 2,
+					},
+					'00:25:96:FF:FE:12:34:53': {
+						angleDeg: 3,
+						driveTimeMs: 3,
+					},
+					'00:25:96:FF:FE:12:34:54': {
+						angleDeg: 4,
+						driveTimeMs: 4,
+					},
+					'00:25:96:FF:FE:12:34:55': {
+						angleDeg: 5,
+						driveTimeMs: 5,
+					},
+					'00:25:96:FF:FE:12:34:56': {
+						angleDeg: 6,
+						driveTimeMs: 6,
+					},
+					'00:25:96:FF:FE:12:34:57': {
+						angleDeg: 7,
+						driveTimeMs: 7,
+					},
+					'00:25:96:FF:FE:12:34:58': {
+						angleDeg: 8,
+						driveTimeMs: 8,
+					},
+				},
+				reported: {
+					round: 0,
+					robots: {
+						'00:25:96:FF:FE:12:34:51': {
+							angleDeg: 0,
+							driveTimeMs: 0,
+							revolutionCount: 0,
+						},
+						'00:25:96:FF:FE:12:34:52': {
+							angleDeg: 0,
+							driveTimeMs: 0,
+							revolutionCount: 0,
+						},
+						'00:25:96:FF:FE:12:34:53': {
+							angleDeg: 0,
+							driveTimeMs: 0,
+							revolutionCount: 0,
+						},
+						'00:25:96:FF:FE:12:34:54': {
+							angleDeg: 0,
+							driveTimeMs: 0,
+							revolutionCount: 0,
+						},
+						'00:25:96:FF:FE:12:34:55': {
+							angleDeg: 0,
+							driveTimeMs: 0,
+							revolutionCount: 0,
+						},
+						'00:25:96:FF:FE:12:34:56': {
+							angleDeg: 0,
+							driveTimeMs: 0,
+							revolutionCount: 0,
+						},
+						'00:25:96:FF:FE:12:34:57': {
+							angleDeg: 0,
+							driveTimeMs: 0,
+							revolutionCount: 0,
+						},
+						'00:25:96:FF:FE:12:34:58': {
+							angleDeg: 0,
+							driveTimeMs: 0,
+							revolutionCount: 0,
+						},
+					},
+				},
+			}),
+		).toEqual({
+			round: 0,
+			robots: {
+				'00:25:96:FF:FE:12:34:51': {
+					angleDeg: 1,
+					driveTimeMs: 2,
+					revolutionCount: 0,
+				},
+				'00:25:96:FF:FE:12:34:52': {
+					angleDeg: 2,
+					driveTimeMs: 2,
+					revolutionCount: 0,
+				},
+				'00:25:96:FF:FE:12:34:53': {
+					angleDeg: 3,
+					driveTimeMs: 3,
+					revolutionCount: 0,
+				},
+				'00:25:96:FF:FE:12:34:54': {
+					angleDeg: 4,
+					driveTimeMs: 4,
+					revolutionCount: 0,
+				},
+				'00:25:96:FF:FE:12:34:55': {
+					angleDeg: 5,
+					driveTimeMs: 5,
+					revolutionCount: 0,
+				},
+				'00:25:96:FF:FE:12:34:56': {
+					angleDeg: 6,
+					driveTimeMs: 6,
+					revolutionCount: 0,
+				},
+				'00:25:96:FF:FE:12:34:57': {
+					angleDeg: 7,
+					driveTimeMs: 7,
+					revolutionCount: 0,
+				},
+				'00:25:96:FF:FE:12:34:58': {
+					angleDeg: 8,
+					driveTimeMs: 8,
+					revolutionCount: 0,
+				},
+			},
+		}))
+})

--- a/src/api/calculateReported.ts
+++ b/src/api/calculateReported.ts
@@ -1,0 +1,33 @@
+import type { Static } from '@sinclair/typebox'
+import type { ReportedRobot } from 'api/updateGameController'
+import type {
+	DesiredGameState,
+	ReportedGameState,
+} from 'api/validateGameControllerShadow'
+
+export const calculateReported = ({
+	robots,
+	reported,
+}: {
+	reported: Static<typeof ReportedGameState>
+	robots: Required<Static<typeof DesiredGameState>>['robots']
+}): Static<typeof ReportedGameState> => {
+	const reportedGameState: Static<typeof ReportedGameState> = {
+		...reported,
+	}
+
+	for (const [robotMac, command] of Object.entries(robots)) {
+		const updatedRobot: ReportedRobot = {
+			...reported.robots[robotMac],
+			angleDeg: command.angleDeg,
+			driveTimeMs: command.driveTimeMs,
+			revolutionCount: 0,
+		}
+		reportedGameState.robots = {
+			...reportedGameState.robots,
+			[robotMac]: updatedRobot,
+		}
+	}
+
+	return reportedGameState
+}

--- a/src/api/getReportedForSimulator.ts
+++ b/src/api/getReportedForSimulator.ts
@@ -1,0 +1,58 @@
+import {
+	GetThingShadowCommand,
+	IoTDataPlaneClient,
+} from '@aws-sdk/client-iot-data-plane'
+import { toUtf8 } from '@aws-sdk/util-utf8-browser'
+import { calculateReported } from 'api/calculateReported'
+import { sendReportedMessage } from 'api/sendReportedMessage'
+import { validateGameControllerShadow } from 'api/validateGameControllerShadow'
+
+export const getReportedForSimulator = async (
+	gameControllerThing?: string,
+	iotDataPlaneClient?: IoTDataPlaneClient,
+): Promise<void> => {
+	if (gameControllerThing === undefined) return
+	if (iotDataPlaneClient === undefined) return
+
+	const currentShadow = await iotDataPlaneClient.send(
+		new GetThingShadowCommand({
+			thingName: gameControllerThing,
+		}),
+	)
+
+	if (currentShadow.payload === undefined) {
+		console.error(`No shadow defined for ${gameControllerThing}`)
+		return
+	}
+
+	const shadow = JSON.parse(toUtf8(currentShadow.payload))
+
+	const maybeValidShadow = validateGameControllerShadow(shadow)
+
+	if ('error' in maybeValidShadow) {
+		console.error(`Failed to validate game controller shadow!`)
+		console.error(maybeValidShadow.error)
+		return
+	}
+
+	const {
+		state: { desired, reported },
+	} = maybeValidShadow
+
+	const desiredGameState = desired ?? {
+		robots: {},
+	}
+
+	if (desiredGameState.robots === undefined) return
+
+	const reportedGameState = calculateReported({
+		reported,
+		robots: desiredGameState.robots,
+	})
+
+	await sendReportedMessage(
+		reportedGameState,
+		gameControllerThing,
+		iotDataPlaneClient,
+	)
+}

--- a/src/api/getReportedForSimulator.ts
+++ b/src/api/getReportedForSimulator.ts
@@ -8,12 +8,9 @@ import { sendReportedMessage } from 'api/sendReportedMessage'
 import { validateGameControllerShadow } from 'api/validateGameControllerShadow'
 
 export const getReportedForSimulator = async (
-	gameControllerThing?: string,
-	iotDataPlaneClient?: IoTDataPlaneClient,
+	gameControllerThing: string,
+	iotDataPlaneClient: IoTDataPlaneClient,
 ): Promise<void> => {
-	if (gameControllerThing === undefined) return
-	if (iotDataPlaneClient === undefined) return
-
 	const currentShadow = await iotDataPlaneClient.send(
 		new GetThingShadowCommand({
 			thingName: gameControllerThing,

--- a/src/api/sendReportedMessage.ts
+++ b/src/api/sendReportedMessage.ts
@@ -1,0 +1,33 @@
+import {
+	IoTDataPlaneClient,
+	UpdateThingShadowCommand,
+} from '@aws-sdk/client-iot-data-plane'
+import { fromUtf8 } from '@aws-sdk/util-utf8-browser'
+import type { Static } from '@sinclair/typebox'
+import type { ReportedGameState } from 'api/validateGameControllerShadow'
+
+export const sendReportedMessage = async (
+	reportedCommand: Static<typeof ReportedGameState>,
+	gameControllerThing?: string,
+	iotDataPlaneClient?: IoTDataPlaneClient,
+): Promise<void> => {
+	if (gameControllerThing === undefined) return
+	if (iotDataPlaneClient === undefined) return
+	await iotDataPlaneClient
+		.send(
+			new UpdateThingShadowCommand({
+				thingName: gameControllerThing,
+				payload: fromUtf8(
+					JSON.stringify({
+						state: {
+							reported: reportedCommand,
+						},
+					}),
+				),
+			}),
+		)
+		.catch((error) => {
+			console.error('Failed to write to  reported shadow')
+			console.error(error)
+		})
+}

--- a/src/api/sendReportedMessage.ts
+++ b/src/api/sendReportedMessage.ts
@@ -8,11 +8,9 @@ import type { ReportedGameState } from 'api/validateGameControllerShadow'
 
 export const sendReportedMessage = async (
 	reportedCommand: Static<typeof ReportedGameState>,
-	gameControllerThing?: string,
-	iotDataPlaneClient?: IoTDataPlaneClient,
+	gameControllerThing: string,
+	iotDataPlaneClient: IoTDataPlaneClient,
 ): Promise<void> => {
-	if (gameControllerThing === undefined) return
-	if (iotDataPlaneClient === undefined) return
 	await iotDataPlaneClient
 		.send(
 			new UpdateThingShadowCommand({

--- a/src/api/updateGateway.ts
+++ b/src/api/updateGateway.ts
@@ -14,7 +14,7 @@ import { validateGameControllerShadow } from 'api/validateGameControllerShadow.j
 export type DesiredRobot = Static<typeof DesiredRobotSchema>
 export type ReportedRobot = Static<typeof ReportedRobotSchema>
 
-export const updateGatewayController =
+export const updateGateway =
 	({
 		iotData,
 		controllerThingName,

--- a/src/api/updateGateway.ts
+++ b/src/api/updateGateway.ts
@@ -6,9 +6,7 @@ import {
 import { fromUtf8, toUtf8 } from '@aws-sdk/util-utf8-browser'
 import type { Static } from '@sinclair/typebox'
 import type {
-	DesiredGameState,
 	DesiredRobot as DesiredRobotSchema,
-	ReportedGameState,
 	ReportedRobot as ReportedRobotSchema,
 } from 'api/validateGameControllerShadow'
 import { validateGameControllerShadow } from 'api/validateGameControllerShadow.js'
@@ -78,30 +76,3 @@ export const updateGatewayController =
 				console.error(error)
 			})
 	}
-
-export const calculateReported = ({
-	robots,
-	reported,
-}: {
-	reported: Static<typeof ReportedGameState>
-	robots: Required<Static<typeof DesiredGameState>>['robots']
-}): Static<typeof ReportedGameState> => {
-	const reportedGameState: Static<typeof ReportedGameState> = {
-		...reported,
-	}
-
-	for (const [robotMac, command] of Object.entries(robots)) {
-		const updatedRobot: ReportedRobot = {
-			...reported.robots[robotMac],
-			angleDeg: command.angleDeg,
-			driveTimeMs: command.driveTimeMs,
-			revolutionCount: 0,
-		}
-		reportedGameState.robots = {
-			...reportedGameState.robots,
-			[robotMac]: updatedRobot,
-		}
-	}
-
-	return reportedGameState
-}

--- a/src/app/pages/GameControllers.tsx
+++ b/src/app/pages/GameControllers.tsx
@@ -1,6 +1,185 @@
-import { useGameController } from 'hooks/useGameController'
+import {
+	GetThingShadowCommand,
+	IoTDataPlaneClient,
+	UpdateThingShadowCommand,
+} from '@aws-sdk/client-iot-data-plane'
+import { fromUtf8, toUtf8 } from '@aws-sdk/util-utf8-browser'
+import type { Static } from '@sinclair/typebox'
+import { calculateReported } from 'api/updateGateway'
+import type { ReportedGameState } from 'api/validateGameControllerShadow'
+import { validateGameControllerShadow } from 'api/validateGameControllerShadow'
+import { Main } from 'components/Main'
+import { useCredentials } from 'hooks/useCredentials'
+import { useGameControllerThing } from 'hooks/useGameControllerThing'
 
 export const GameControllers = () => {
-	const { gameState } = useGameController()
-	return <div>{JSON.stringify(gameState)}</div>
+	const robotCommands = {
+		round: 1,
+		robots: {
+			'00:25:96:FF:FE:12:34:51': {
+				angleDeg: 0,
+				driveTimeMs: 0,
+				revolutionCount: 0,
+			},
+			'00:25:96:FF:FE:12:34:52': {
+				angleDeg: 0,
+				driveTimeMs: 0,
+				revolutionCount: 0,
+			},
+			'00:25:96:FF:FE:12:34:53': {
+				angleDeg: 0,
+				driveTimeMs: 0,
+				revolutionCount: 0,
+			},
+			'00:25:96:FF:FE:12:34:54': {
+				angleDeg: 0,
+				driveTimeMs: 0,
+				revolutionCount: 0,
+			},
+			'00:25:96:FF:FE:12:34:55': {
+				angleDeg: 0,
+				driveTimeMs: 0,
+				revolutionCount: 0,
+			},
+			'00:25:96:FF:FE:12:34:56': {
+				angleDeg: 0,
+				driveTimeMs: 0,
+				revolutionCount: 0,
+			},
+			'00:25:96:FF:FE:12:34:57': {
+				angleDeg: 0,
+				driveTimeMs: 0,
+				revolutionCount: 0,
+			},
+			'00:25:96:FF:FE:12:34:58': {
+				angleDeg: 0,
+				driveTimeMs: 0,
+				revolutionCount: 0,
+			},
+		},
+	} //What we want to send to the shadow in step 3
+
+	const { thingName: gameControllerThing } = useGameControllerThing()
+	const { accessKeyId, secretAccessKey, region } = useCredentials()
+
+	let iotDataPlaneClient: IoTDataPlaneClient | undefined = undefined
+
+	if (accessKeyId === undefined || secretAccessKey === undefined) {
+		console.debug('AWS credentials not available')
+	} else {
+		iotDataPlaneClient = new IoTDataPlaneClient({
+			region,
+			credentials: {
+				accessKeyId,
+				secretAccessKey,
+			},
+		})
+	}
+
+	//function that sends the first reported message
+	const sendReportedMessage = async (
+		reportedCommand: Static<typeof ReportedGameState>,
+	) => {
+		if (gameControllerThing === undefined) return
+		if (iotDataPlaneClient === undefined) return
+
+		await iotDataPlaneClient
+			.send(
+				new UpdateThingShadowCommand({
+					thingName: gameControllerThing,
+					payload: fromUtf8(
+						JSON.stringify({
+							state: {
+								reported: reportedCommand,
+							},
+						}),
+					),
+				}),
+			)
+			.catch((error) => {
+				console.error('Failed to write to  reported shadow')
+				console.error(error)
+			})
+	}
+
+	const getDesiredValuesAndReportBack = async () => {
+		if (gameControllerThing === undefined) return
+		if (iotDataPlaneClient === undefined) return
+
+		const currentShadow = await iotDataPlaneClient.send(
+			new GetThingShadowCommand({
+				thingName: gameControllerThing,
+			}),
+		)
+
+		if (currentShadow.payload === undefined) {
+			console.error(`No shadow defined for ${gameControllerThing}`)
+			return
+		}
+
+		const shadow = JSON.parse(toUtf8(currentShadow.payload))
+
+		const maybeValidShadow = validateGameControllerShadow(shadow)
+
+		if ('error' in maybeValidShadow) {
+			console.error(`Failed to validate game controller shadow!`)
+			console.error(maybeValidShadow.error)
+			return
+		}
+
+		const {
+			state: { desired, reported },
+		} = maybeValidShadow
+
+		const desiredGameState = desired ?? {
+			robots: {},
+		}
+
+		if (desiredGameState.robots === undefined) return
+
+		// Start
+
+		const reportedGameState = calculateReported({
+			reported,
+			robots: desiredGameState.robots,
+		})
+
+		// Finish!
+		await sendReportedMessage(reportedGameState)
+	}
+
+	return (
+		<Main>
+			<div className="card">
+				<div className="card-header">Steps</div>
+				<div className="card-body">
+					<ol>
+						<li> Trigging the first reported state from the robot</li>
+						<button
+							onClick={async () => {
+								await sendReportedMessage(robotCommands)
+							}}
+						>
+							SEND FIRST REPORTED MESSAGE
+						</button>
+						{/*Robots should appear on admin and game*/}
+						<li> Set angle and drivetime in Game page </li>
+						{/*Robots does their thing, and reports back. Get values from desired and put them into reported --> SEND REPORT WITH BUTTON*/}
+						<li> Robot gets the desired values, and reports back</li>
+						<button
+							type="button"
+							className="btn btn-danger"
+							onClick={async () => {
+								await getDesiredValuesAndReportBack()
+							}}
+						>
+							SEND REPORTED
+						</button>
+						<li>Place robots in admin page</li>
+					</ol>
+					<p>Repeat step 2,3 and 4 to go through the game</p>
+				</div>
+			</div>
+		</Main>
+	)
 }

--- a/src/app/pages/GameControllers.tsx
+++ b/src/app/pages/GameControllers.tsx
@@ -24,6 +24,25 @@ export const GameControllers = () => {
 		})
 	}
 
+	// TODO: explain how the user can select a game controller
+	if (gameControllerThing === undefined)
+		return (
+			<Main>
+				<div className="alert alert-danger">
+					Help! No game controller selected!
+				</div>
+			</Main>
+		)
+
+	if (iotDataPlaneClient === undefined)
+		return (
+			<Main>
+				<div className="alert alert-danger">
+					Help! No AWS credentials defined!
+				</div>
+			</Main>
+		)
+
 	return (
 		<Main>
 			<div className="card">
@@ -36,7 +55,7 @@ export const GameControllers = () => {
 								await sendReportedMessage(
 									robotCommands,
 									gameControllerThing,
-									iotDataPlaneClient,
+									iotDataPlaneClient as IoTDataPlaneClient,
 								)
 							}}
 						>
@@ -50,7 +69,7 @@ export const GameControllers = () => {
 							onClick={async () => {
 								await getReportedForSimulator(
 									gameControllerThing,
-									iotDataPlaneClient,
+									iotDataPlaneClient as IoTDataPlaneClient,
 								)
 							}}
 						>

--- a/src/app/pages/GameControllers.tsx
+++ b/src/app/pages/GameControllers.tsx
@@ -1,64 +1,12 @@
-import {
-	GetThingShadowCommand,
-	IoTDataPlaneClient,
-	UpdateThingShadowCommand,
-} from '@aws-sdk/client-iot-data-plane'
-import { fromUtf8, toUtf8 } from '@aws-sdk/util-utf8-browser'
-import type { Static } from '@sinclair/typebox'
-import { calculateReported } from 'api/updateGateway'
-import type { ReportedGameState } from 'api/validateGameControllerShadow'
-import { validateGameControllerShadow } from 'api/validateGameControllerShadow'
+import { IoTDataPlaneClient } from '@aws-sdk/client-iot-data-plane'
+import { getReportedForSimulator } from 'api/getReportedForSimulator'
+import { sendReportedMessage } from 'api/sendReportedMessage'
 import { Main } from 'components/Main'
 import { useCredentials } from 'hooks/useCredentials'
 import { useGameControllerThing } from 'hooks/useGameControllerThing'
+import { robotCommands } from 'utils/initialReportedState'
 
 export const GameControllers = () => {
-	const robotCommands = {
-		round: 1,
-		robots: {
-			'00:25:96:FF:FE:12:34:51': {
-				angleDeg: 0,
-				driveTimeMs: 0,
-				revolutionCount: 0,
-			},
-			'00:25:96:FF:FE:12:34:52': {
-				angleDeg: 0,
-				driveTimeMs: 0,
-				revolutionCount: 0,
-			},
-			'00:25:96:FF:FE:12:34:53': {
-				angleDeg: 0,
-				driveTimeMs: 0,
-				revolutionCount: 0,
-			},
-			'00:25:96:FF:FE:12:34:54': {
-				angleDeg: 0,
-				driveTimeMs: 0,
-				revolutionCount: 0,
-			},
-			'00:25:96:FF:FE:12:34:55': {
-				angleDeg: 0,
-				driveTimeMs: 0,
-				revolutionCount: 0,
-			},
-			'00:25:96:FF:FE:12:34:56': {
-				angleDeg: 0,
-				driveTimeMs: 0,
-				revolutionCount: 0,
-			},
-			'00:25:96:FF:FE:12:34:57': {
-				angleDeg: 0,
-				driveTimeMs: 0,
-				revolutionCount: 0,
-			},
-			'00:25:96:FF:FE:12:34:58': {
-				angleDeg: 0,
-				driveTimeMs: 0,
-				revolutionCount: 0,
-			},
-		},
-	} //What we want to send to the shadow in step 3
-
 	const { thingName: gameControllerThing } = useGameControllerThing()
 	const { accessKeyId, secretAccessKey, region } = useCredentials()
 
@@ -76,78 +24,6 @@ export const GameControllers = () => {
 		})
 	}
 
-	//function that sends the first reported message
-	const sendReportedMessage = async (
-		reportedCommand: Static<typeof ReportedGameState>,
-	) => {
-		if (gameControllerThing === undefined) return
-		if (iotDataPlaneClient === undefined) return
-
-		await iotDataPlaneClient
-			.send(
-				new UpdateThingShadowCommand({
-					thingName: gameControllerThing,
-					payload: fromUtf8(
-						JSON.stringify({
-							state: {
-								reported: reportedCommand,
-							},
-						}),
-					),
-				}),
-			)
-			.catch((error) => {
-				console.error('Failed to write to  reported shadow')
-				console.error(error)
-			})
-	}
-
-	const getDesiredValuesAndReportBack = async () => {
-		if (gameControllerThing === undefined) return
-		if (iotDataPlaneClient === undefined) return
-
-		const currentShadow = await iotDataPlaneClient.send(
-			new GetThingShadowCommand({
-				thingName: gameControllerThing,
-			}),
-		)
-
-		if (currentShadow.payload === undefined) {
-			console.error(`No shadow defined for ${gameControllerThing}`)
-			return
-		}
-
-		const shadow = JSON.parse(toUtf8(currentShadow.payload))
-
-		const maybeValidShadow = validateGameControllerShadow(shadow)
-
-		if ('error' in maybeValidShadow) {
-			console.error(`Failed to validate game controller shadow!`)
-			console.error(maybeValidShadow.error)
-			return
-		}
-
-		const {
-			state: { desired, reported },
-		} = maybeValidShadow
-
-		const desiredGameState = desired ?? {
-			robots: {},
-		}
-
-		if (desiredGameState.robots === undefined) return
-
-		// Start
-
-		const reportedGameState = calculateReported({
-			reported,
-			robots: desiredGameState.robots,
-		})
-
-		// Finish!
-		await sendReportedMessage(reportedGameState)
-	}
-
 	return (
 		<Main>
 			<div className="card">
@@ -157,20 +33,25 @@ export const GameControllers = () => {
 						<li> Trigging the first reported state from the robot</li>
 						<button
 							onClick={async () => {
-								await sendReportedMessage(robotCommands)
+								await sendReportedMessage(
+									robotCommands,
+									gameControllerThing,
+									iotDataPlaneClient,
+								)
 							}}
 						>
 							SEND FIRST REPORTED MESSAGE
 						</button>
-						{/*Robots should appear on admin and game*/}
 						<li> Set angle and drivetime in Game page </li>
-						{/*Robots does their thing, and reports back. Get values from desired and put them into reported --> SEND REPORT WITH BUTTON*/}
 						<li> Robot gets the desired values, and reports back</li>
 						<button
 							type="button"
 							className="btn btn-danger"
 							onClick={async () => {
-								await getDesiredValuesAndReportBack()
+								await getReportedForSimulator(
+									gameControllerThing,
+									iotDataPlaneClient,
+								)
 							}}
 						>
 							SEND REPORTED

--- a/src/utils/initialReportedState.ts
+++ b/src/utils/initialReportedState.ts
@@ -1,4 +1,7 @@
-export const robotCommands = {
+import type { Static } from '@sinclair/typebox'
+import type { ReportedGameState } from 'api/validateGameControllerShadow'
+
+export const robotCommands: Static<typeof ReportedGameState> = {
 	round: 1,
 	robots: {
 		'00:25:96:FF:FE:12:34:51': {

--- a/src/utils/initialReportedState.ts
+++ b/src/utils/initialReportedState.ts
@@ -1,0 +1,45 @@
+export const robotCommands = {
+	round: 1,
+	robots: {
+		'00:25:96:FF:FE:12:34:51': {
+			angleDeg: 0,
+			driveTimeMs: 0,
+			revolutionCount: 0,
+		},
+		'00:25:96:FF:FE:12:34:52': {
+			angleDeg: 0,
+			driveTimeMs: 0,
+			revolutionCount: 0,
+		},
+		'00:25:96:FF:FE:12:34:53': {
+			angleDeg: 0,
+			driveTimeMs: 0,
+			revolutionCount: 0,
+		},
+		'00:25:96:FF:FE:12:34:54': {
+			angleDeg: 0,
+			driveTimeMs: 0,
+			revolutionCount: 0,
+		},
+		'00:25:96:FF:FE:12:34:55': {
+			angleDeg: 0,
+			driveTimeMs: 0,
+			revolutionCount: 0,
+		},
+		'00:25:96:FF:FE:12:34:56': {
+			angleDeg: 0,
+			driveTimeMs: 0,
+			revolutionCount: 0,
+		},
+		'00:25:96:FF:FE:12:34:57': {
+			angleDeg: 0,
+			driveTimeMs: 0,
+			revolutionCount: 0,
+		},
+		'00:25:96:FF:FE:12:34:58': {
+			angleDeg: 0,
+			driveTimeMs: 0,
+			revolutionCount: 0,
+		},
+	},
+}


### PR DESCRIPTION
On game controller we have now one button that sets an initial reported robots in the shadow, and one button that updates the reported robots with the values from the desired robots, in order to get some updates and play through the game, without actually having any real robots connected. Also added a test that checks that the reported shadow is correctly formatted and that the values of the angle and drive time is correct. 