### PR TITLE
Fix: Prevent rotation angles out of range

### DIFF
--- a/src/app/pages/Admin.tsx
+++ b/src/app/pages/Admin.tsx
@@ -6,6 +6,10 @@ import { useAppConfig } from 'hooks/useAppConfig'
 import { useGameAdmin } from 'hooks/useGameAdmin'
 import { useGameController } from 'hooks/useGameController'
 import { useEffect, useState } from 'react'
+import {
+	angleAfterFullRotation,
+	convertToPositiveAngle,
+} from 'utils/degreeConversion.js'
 import { randomColor } from 'utils/randomColor'
 
 type RobotFieldConfig = Record<
@@ -102,17 +106,20 @@ export const Admin = () => {
 								}
 								rotationDeg={rotationDeg}
 								onRotate={(rotation) => {
+									const nextRotationDeg = convertToPositiveAngle(
+										angleAfterFullRotation(rotationDeg + rotation),
+									)
 									setRobots((robots) => ({
 										...robots,
 										[mac]: {
 											...robots[mac],
-											rotationDeg: rotationDeg + rotation,
+											rotationDeg: nextRotationDeg,
 										},
 									}))
 									adminSetRobotPosition(mac, {
 										xMm: robots[mac].xMm,
 										yMm: robots[mac].yMm,
-										rotationDeg: rotationDeg + rotation,
+										rotationDeg: nextRotationDeg,
 									})
 								}}
 								onClick={() => {

--- a/src/app/pages/Game.tsx
+++ b/src/app/pages/Game.tsx
@@ -9,6 +9,10 @@ import { RobotCommand, useGameController } from 'hooks/useGameController'
 import { useRobotActionGesture } from 'hooks/useRobotActionGesture'
 import { useScrollBlock } from 'hooks/useScrollBlock'
 import { useEffect, useState } from 'react'
+import {
+	angleAfterFullRotation,
+	convertToPositiveAngle,
+} from 'utils/degreeConversion.js'
 import { randomColor } from 'utils/randomColor'
 import { shortestRotation } from 'utils/shortestRotation'
 
@@ -142,7 +146,11 @@ export const Game = () => {
 									heightMm={robotLengthMm}
 									colorHex={colorHex}
 									rotationDeg={rotationDeg}
-									desiredRotationDeg={rotationDeg + nextRobotCommand.angleDeg}
+									desiredRotationDeg={convertToPositiveAngle(
+										angleAfterFullRotation(
+											rotationDeg + nextRobotCommand.angleDeg,
+										),
+									)}
 									desiredDriveTime={nextRobotCommand.driveTimeMs}
 									desiredDriveBudgetPercent={
 										isSameTeam ? (nextRobotCommand.driveTimeMs ?? 0) / 1000 : 0

--- a/src/utils/degreeConversion.spec.ts
+++ b/src/utils/degreeConversion.spec.ts
@@ -1,4 +1,7 @@
-import { degreeConversion } from 'utils/degreeConversion.js'
+import {
+	angleAfterFullRotation,
+	degreeConversion,
+} from 'utils/degreeConversion.js'
 
 describe('degreeConversion()', () => {
 	describe('Should takes a value, which is in 180 format, and allows conversion to 360 format', () => {
@@ -45,6 +48,20 @@ describe('degreeConversion()', () => {
 			[-0, 0],
 		])('%d -> %d', (given, expected) =>
 			expect(degreeConversion(given)).toEqual(expected),
+		)
+	})
+})
+
+describe('angleAfterFullRotation()', () => {
+	describe('Should takes a value and returns it new position on the circle after rotation if happens', () => {
+		it.each([
+			[500, 140],
+			[-800, -80],
+			[90, 90],
+			[630, 270],
+			[361, 1],
+		])('%d -> %d', (given, expected) =>
+			expect(angleAfterFullRotation(given)).toEqual(expected),
 		)
 	})
 })

--- a/src/utils/degreeConversion.spec.ts
+++ b/src/utils/degreeConversion.spec.ts
@@ -1,10 +1,41 @@
 import {
 	angleAfterFullRotation,
-	degreeConversion,
+	convertToPositiveAngle,
 } from 'utils/degreeConversion.js'
 
-describe('degreeConversion()', () => {
-	describe('Should takes a value, which is in 180 format, and allows conversion to 360 format', () => {
+describe('angleAfterFullRotation()', () => {
+	describe('Should takes a value and returns it new position after rotation if happens', () => {
+		it.each([
+			[500, 140],
+			[-800, -80],
+			[90, 90],
+			[630, 270],
+			[361, 1],
+			[-990, -270],
+		])('%d -> %d', (given, expected) =>
+			expect(angleAfterFullRotation(given)).toEqual(expected),
+		)
+	})
+})
+
+describe('convertToPositiveAngle()', () => {
+	describe('Should return expected values', () => {
+		it.each([
+			[0, 0],
+			[90, 90],
+			[180, 180],
+			[360, 0],
+			[-0, 0],
+			[-90, 270],
+			[-180, 180],
+			[-270, 90],
+			[-360, 0],
+		])('%d -> %d', (given, expected) =>
+			expect(convertToPositiveAngle(given)).toEqual(expected),
+		)
+	})
+
+	describe('Should return positive angles between [0,360]', () => {
 		it.each([
 			[0],
 			[37],
@@ -24,44 +55,17 @@ describe('degreeConversion()', () => {
 			[-15],
 			[-0],
 		])('%d', (degree) => {
-			const result = degreeConversion(degree)
+			const result = convertToPositiveAngle(degree)
 			expect(result).toBeGreaterThanOrEqual(0)
 			expect(result).toBeLessThanOrEqual(360)
 		})
 	})
 
-	describe('Should not allow to convert values out to the range of [-180 , 180]', () => {
-		it.each([[-181], [181], [360], [-360]])('%d', (degree) =>
-			expect(() => degreeConversion(degree)).toThrow(
+	describe('Should not allow to convert values out to the range of [-360 , 360]', () => {
+		it.each([[-361], [361], [720], [-720]])('%d', (degree) =>
+			expect(() => convertToPositiveAngle(degree)).toThrow(
 				`Degree is out of range: ${degree}.`,
 			),
-		)
-	})
-
-	describe('Should takes value and return in its equivalent value in 360 format: %d', () => {
-		it.each([
-			[0, 0],
-			[90, 90],
-			[180, 180],
-			[-180, 180],
-			[-90, 270],
-			[-0, 0],
-		])('%d -> %d', (given, expected) =>
-			expect(degreeConversion(given)).toEqual(expected),
-		)
-	})
-})
-
-describe('angleAfterFullRotation()', () => {
-	describe('Should takes a value and returns it new position on the circle after rotation if happens', () => {
-		it.each([
-			[500, 140],
-			[-800, -80],
-			[90, 90],
-			[630, 270],
-			[361, 1],
-		])('%d -> %d', (given, expected) =>
-			expect(angleAfterFullRotation(given)).toEqual(expected),
 		)
 	})
 })

--- a/src/utils/degreeConversion.spec.ts
+++ b/src/utils/degreeConversion.spec.ts
@@ -1,0 +1,50 @@
+import { degreeConversion } from 'utils/degreeConversion.js'
+
+describe('degreeConversion()', () => {
+	describe('Should takes a value, which is in 180 format, and allows conversion to 360 format', () => {
+		it.each([
+			[0],
+			[37],
+			[45],
+			[54],
+			[90],
+			[100],
+			[161],
+			[180],
+			[-180],
+			[-145],
+			[-100],
+			[-90],
+			[-78],
+			[-45],
+			[-22],
+			[-15],
+			[-0],
+		])('%d', (degree) => {
+			const result = degreeConversion(degree)
+			expect(result).toBeGreaterThanOrEqual(0)
+			expect(result).toBeLessThanOrEqual(360)
+		})
+	})
+
+	describe('Should not allow to convert values out to the range of [-180 , 180]', () => {
+		it.each([[-181], [181], [360], [-360]])('%d', (degree) =>
+			expect(() => degreeConversion(degree)).toThrow(
+				`Degree is out of range: ${degree}.`,
+			),
+		)
+	})
+
+	describe('Should takes value and return in its equivalent value in 360 format: %d', () => {
+		it.each([
+			[0, 0],
+			[90, 90],
+			[180, 180],
+			[-180, 180],
+			[-90, 270],
+			[-0, 0],
+		])('%d -> %d', (given, expected) =>
+			expect(degreeConversion(given)).toEqual(expected),
+		)
+	})
+})

--- a/src/utils/degreeConversion.ts
+++ b/src/utils/degreeConversion.ts
@@ -1,8 +1,8 @@
 /**
- * Convert a degree from 180 format to 360
+ * Given an angle between [-360, 360], place it in range [0, 360]
  */
-export const degreeConversion = (degree: number): number => {
-	if (degree > 180 || degree < -180)
+export const convertToPositiveAngle = (degree: number): number => {
+	if (degree > 360 || degree < -360)
 		throw new Error(`Degree is out of range: ${degree}.`)
 	return (degree + 360) % 360
 }

--- a/src/utils/degreeConversion.ts
+++ b/src/utils/degreeConversion.ts
@@ -1,0 +1,5 @@
+export const degreeConversion = (degree: number): number => {
+	if (degree > 180 || degree < -180)
+		throw new Error(`Degree is out of range: ${degree}.`)
+	return (degree + 360) % 360
+}

--- a/src/utils/degreeConversion.ts
+++ b/src/utils/degreeConversion.ts
@@ -6,3 +6,11 @@ export const degreeConversion = (degree: number): number => {
 		throw new Error(`Degree is out of range: ${degree}.`)
 	return (degree + 360) % 360
 }
+
+/**
+ * Takes a value and return its angle after a full rotation.
+ * This is specially helpful when angles are bigger than 360
+ */
+export const angleAfterFullRotation = (degree: number): number => {
+	return degree > -360 && degree < 360 ? degree : degree % 360
+}

--- a/src/utils/degreeConversion.ts
+++ b/src/utils/degreeConversion.ts
@@ -1,3 +1,6 @@
+/**
+ * Convert a degree from 180 format to 360
+ */
 export const degreeConversion = (degree: number): number => {
 	if (degree > 180 || degree < -180)
 		throw new Error(`Degree is out of range: ${degree}.`)


### PR DESCRIPTION
as is specified in `src/api/validateGameAdminShadow.ts` and pointed out in https://github.com/NordicPlayground/robot-war-app/pull/32 , `rotation degrees` must be between [0, 359]. 

Create method to make degree conversation in cases where it is needed in order to follow the last mentioned rule. 

Test cases for different scenarios were added as well. 