### PR TITLE
Fix: rotation as an admin

### DIFF
--- a/src/app/pages/Admin.tsx
+++ b/src/app/pages/Admin.tsx
@@ -7,6 +7,7 @@ import type { RobotPosition } from 'core/models/RobotPosition'
 import equal from 'fast-deep-equal'
 import { useAppConfig } from 'hooks/useAppConfig'
 import { useCore } from 'hooks/useCore'
+import { useScrollBlock } from 'hooks/useScrollBlock'
 import { useEffect, useState } from 'react'
 import { shortestRotation360 } from 'utils/shortestRotation'
 import { teamColor } from 'utils/teamColor.js'
@@ -20,6 +21,7 @@ export const Admin = () => {
 	} = useCore()
 
 	const [selectedRobot, setSelectedRobot] = useState<string>()
+	const [blockScroll, allowScroll] = useScrollBlock()
 
 	// Create inital positions and rotation on the map
 	// Distribute robots alternating in start zones of teams
@@ -107,6 +109,12 @@ export const Admin = () => {
 							}}
 							onPointerDown={() => {
 								setSelectedRobot(mac)
+							}}
+							onPointerEnter={() => {
+								blockScroll()
+							}}
+							onPointerLeave={() => {
+								allowScroll()
 							}}
 						/>
 					))}

--- a/src/components/Game/Robot.spec.tsx
+++ b/src/components/Game/Robot.spec.tsx
@@ -166,4 +166,50 @@ T = tip
 		})
 		expect(onPointerUp).toHaveBeenCalledTimes(1)
 	})
+
+	it('Should trigger onPointerEnter', () => {
+		const onPointerEnter = jest.fn()
+
+		const robot = isolateComponent(
+			<Robot
+				colorHex={randomColor()}
+				heightMm={100}
+				widthMm={100}
+				id={randomMac()}
+				xMm={0}
+				yMm={0}
+				rotationDeg={0}
+				onPointerEnter={onPointerEnter}
+			/>,
+		)
+
+		// Simulating a mouse entering the robot
+		robot.findOne('[data-test-id=robot]').props.onPointerEnter({
+			stopPropagation: jest.fn(),
+		})
+		expect(onPointerEnter).toHaveBeenCalledTimes(1)
+	})
+
+	it('Should trigger onPointerLeave', () => {
+		const onPointerLeave = jest.fn()
+
+		const robot = isolateComponent(
+			<Robot
+				colorHex={randomColor()}
+				heightMm={100}
+				widthMm={100}
+				id={randomMac()}
+				xMm={0}
+				yMm={0}
+				rotationDeg={0}
+				onPointerLeave={onPointerLeave}
+			/>,
+		)
+
+		// Simulating a mouse leaving the robot
+		robot.findOne('[data-test-id=robot]').props.onPointerLeave({
+			stopPropagation: jest.fn(),
+		})
+		expect(onPointerLeave).toHaveBeenCalledTimes(1)
+	})
 })

--- a/src/components/Game/Robot.tsx
+++ b/src/components/Game/Robot.tsx
@@ -26,6 +26,8 @@ export const Robot = ({
 	outline,
 	onPointerDown,
 	onPointerUp,
+	onPointerEnter,
+	onPointerLeave,
 }: {
 	id: string
 	xMm: number
@@ -40,6 +42,8 @@ export const Robot = ({
 	onPointerDown?: (args: { x: number; y: number }) => void
 	onPointerUp?: () => void
 	outline?: boolean
+	onPointerEnter?: () => void
+	onPointerLeave?: () => void
 }) => {
 	// Construct points for a triangle.
 	const points: [number, number][] = []
@@ -62,6 +66,14 @@ export const Robot = ({
 			onPointerUp={(e) => {
 				e.stopPropagation()
 				onPointerUp?.()
+			}}
+			onPointerEnter={(e) => {
+				e.stopPropagation()
+				onPointerEnter?.()
+			}}
+			onPointerLeave={(e) => {
+				e.stopPropagation()
+				onPointerLeave?.()
 			}}
 		>
 			<defs>

--- a/src/hooks/useScrollBlock.tsx
+++ b/src/hooks/useScrollBlock.tsx
@@ -3,12 +3,12 @@ import { useRef } from 'react'
 const safeDocument: Document = document
 
 export const useScrollBlock = (): [() => void, () => void] => {
-	const scrollBlocked = useRef(false)
+	const isScrollBlocked = useRef(false)
 	const html = safeDocument.documentElement
 	const { body } = safeDocument
 
 	const blockScroll = (): void => {
-		if (body == null || body.style == null || scrollBlocked.current) return
+		if (body == null || body.style == null || isScrollBlocked.current) return
 		if (document === undefined) return
 
 		const scrollBarWidth = window.innerWidth - html.clientWidth
@@ -23,11 +23,11 @@ export const useScrollBlock = (): [() => void, () => void] => {
 		body.style.overflow = 'hidden' /* [2] */
 		body.style.paddingRight = `${bodyPaddingRight + scrollBarWidth}px`
 
-		scrollBlocked.current = true
+		isScrollBlocked.current = true
 	}
 
 	const allowScroll = (): void => {
-		if (body == null || body.style == null || !scrollBlocked.current) return
+		if (body == null || body.style == null || !isScrollBlocked.current) return
 
 		html.style.position = ''
 		html.style.overflow = ''
@@ -35,7 +35,7 @@ export const useScrollBlock = (): [() => void, () => void] => {
 		body.style.overflow = ''
 		body.style.paddingRight = ''
 
-		scrollBlocked.current = false
+		isScrollBlocked.current = false
 	}
 
 	return [blockScroll, allowScroll]


### PR DESCRIPTION
> **TLDR**; This solution is, in terms of agile methodology, what give us more value to solve the issue we have been having on the admin view related to the rotation which right now is not functional. 

 **Problem**
Previously, when an admin wants to rotate a robot, they use the wheel from mouse. But doing that, they are triggering the scrolling as well, which make the rotation not functional in the admin view. 

**Options**
To solve this, we have 2 options: A) simulate the rotation system we already have in the user view. B) Block the scrolling when we are using the mouse wheel hover the robot on admin view. 

**Evaluation**
About the option A, it looks like a good option however we have a situation there. And the thing is that in the admin view we have the "positioning of robots" feature, which is triggering with the onClick event on the robot, and the rotation system we have in User view uses 'pointer up' and 'pointer down' events. Pointer events includes click events as well, what means that using the system we have been using on User view will interact with the positioning feature we have in admin view. 

We can solve this giving different trigger to the rotation action as for example the double click event. But it also mean we have to think in other option to do the same behavior for admin but in a mobile view, because double click does not exist in that context. 

In other hand, about option B, we already have a hook that allow us to block/allow the scroll whenever we want. The only thing pending there is to add proper events to trigger the desired action.  

**Decision**
Taking in consideration the problem, which is the not functionality of the rotation in the admin view, and the amount of work required for each possible solution, I decided to implement option B and evaluate with the team if there is any specific value adding rotation as is on user view on the admin view.
