### PR TITLE
fix: warning message on console resolved

### DIFF
--- a/src/components/Game/RobotConfig.tsx
+++ b/src/components/Game/RobotConfig.tsx
@@ -24,7 +24,7 @@ export const RobotConfig = ({
 	)
 	return (
 		<Main>
-			<form className="card">
+			<div className="card">
 				<div
 					className="card-header"
 					style={{
@@ -121,7 +121,7 @@ export const RobotConfig = ({
 						</div>
 					</fieldset>
 				</div>
-			</form>
+			</div>
 		</Main>
 	)
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/107171119/181764343-397e5559-386a-48e4-aaca-2b7df64a8048.png)

I got this warning in my console on the webpage, I switched out the <form> with a <div> which seemed to resolve the issue, not sure if it's the best way to resolve it though. 