### PR TITLE
fix: update gateway only when all teams are ready to fight

### DIFF
--- a/src/core/gameEngine.gateway.spec.ts
+++ b/src/core/gameEngine.gateway.spec.ts
@@ -56,15 +56,25 @@ describe('Gateway', () => {
 
 			const listener = jest.fn()
 			game.on(GameEngineEventType.teams_ready_to_fight, listener)
+			game.on(GameEngineEventType.robot_movement_set, listener)
 
 			// Team A marks ready to fight
 			game.teamFight(teamA)
 			expect(listener).not.toHaveBeenCalledWith({
 				name: GameEngineEventType.teams_ready_to_fight,
 			})
+			expect(listener).not.toHaveBeenCalledWith({
+				name: GameEngineEventType.robot_movement_set,
+			})
 
 			// Team B marks ready to fight, now all teams are ready
 			game.teamFight(teamB)
+
+			expect(listener).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: GameEngineEventType.robot_movement_set,
+				}),
+			)
 			expect(listener).toHaveBeenCalledWith({
 				name: GameEngineEventType.teams_ready_to_fight,
 			})
@@ -88,6 +98,7 @@ describe('Gateway', () => {
 			const game = simpleGame()
 			const listener = jest.fn()
 			game.on(GameEngineEventType.teams_ready_to_fight, listener)
+			game.on(GameEngineEventType.robot_movement_set, listener)
 
 			const r1 = randomMac()
 			const r2 = randomMac()
@@ -103,12 +114,20 @@ describe('Gateway', () => {
 
 			game.teamFight('Team A')
 			game.teamFight('Team B')
+			expect(listener).not.toHaveBeenCalledWith({
+				name: GameEngineEventType.robot_movement_set,
+			})
 			expect(listener).not.toHaveBeenLastCalledWith({
 				name: GameEngineEventType.teams_ready_to_fight,
 			})
 
 			// Only when all three teams are ready!
 			game.teamFight('Team C')
+			expect(listener).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: GameEngineEventType.robot_movement_set,
+				}),
+			)
 			expect(listener).toHaveBeenLastCalledWith({
 				name: GameEngineEventType.teams_ready_to_fight,
 			})

--- a/src/core/gameEngine.team.spec.ts
+++ b/src/core/gameEngine.team.spec.ts
@@ -76,7 +76,7 @@ describe('The team should not be able to change the desired robot positions afte
 			})
 		})
 
-		test('that an event is emitted when the desired movement is set by the user', () => {
+		test('that an event is emitted when fight is confirmed by all teams', () => {
 			const listener = jest.fn()
 			const game = simpleGame()
 			const robot1 = randomMac()
@@ -96,6 +96,8 @@ describe('The team should not be able to change the desired robot positions afte
 				angleDeg: 90,
 				driveTimeMs: 500,
 			})
+
+			game.teamFight('Team A')
 
 			expect(game.robots()).toMatchObject({
 				[robot1]: { angleDeg: 90, driveTimeMs: 500 },

--- a/src/core/gameEngine.ts
+++ b/src/core/gameEngine.ts
@@ -309,16 +309,8 @@ export const gameEngine = ({
 				positions,
 			})
 		},
-		teamSetRobotMovement: (address, { angleDeg, driveTimeMs }) => {
-			updateRobotMovement(address, angleDeg, driveTimeMs)
-
-			notify({
-				name: GameEngineEventType.robot_movement_set,
-				address,
-				angleDeg,
-				driveTimeMs,
-			})
-		},
+		teamSetRobotMovement: (address, { angleDeg, driveTimeMs }) =>
+			updateRobotMovement(address, angleDeg, driveTimeMs),
 		teamSetAllRobotMovements: (movements) => {
 			Object.entries(movements).forEach(
 				([robotAddress, { angleDeg, driveTimeMs }]) => {
@@ -346,6 +338,16 @@ export const gameEngine = ({
 			teamsReady.push(team)
 			const allReady = areAllTeamsReady()
 			if (allReady) {
+				Object.entries(robots).forEach(
+					([address, { angleDeg, driveTimeMs }]) => {
+						notify({
+							name: GameEngineEventType.robot_movement_set,
+							address,
+							angleDeg,
+							driveTimeMs,
+						})
+					},
+				)
 				notify({
 					name: GameEngineEventType.teams_ready_to_fight,
 				})


### PR DESCRIPTION
Right now the gateway is updated just after the user set the desired movement for a single robot, that makes the robot moves even when the 'fight' button havent been pressed.

The rules of the game said that the robot should move only when all the teams are ready to fight.

To accomplish that rule, the notification to the gateway have been removed when the user set the desired movement for a robot and insteand do it when all the teams are ready to fight

Co-authored-by: Kaja Koren <kaja.koren@nordicsemi.no>