### PR TITLE
fix: reduction of robot name fixes #4 and fixes #5

### DIFF
--- a/src/components/Admin/RobotTeamAssigner.tsx
+++ b/src/components/Admin/RobotTeamAssigner.tsx
@@ -1,5 +1,6 @@
 import { useCore } from 'hooks/useCore'
 import { useState } from 'react'
+import { shortId } from 'utils/shortId.js'
 import { teamColor } from 'utils/teamColor'
 
 export const RobotTeamAssigner = () => {
@@ -27,7 +28,7 @@ export const RobotTeamAssigner = () => {
 						)
 						.map(([address, robot]) => (
 							<li key={address}>
-								{address.slice(0, 3) + ' '}
+								{shortId(address) + ' '}
 								<RobotTeam
 									address={address}
 									team={robot.team}

--- a/src/components/Admin/RobotTeamAssigner.tsx
+++ b/src/components/Admin/RobotTeamAssigner.tsx
@@ -60,7 +60,7 @@ const RobotTeam = ({
 
 	return (
 		<>
-			<label htmlFor={`robot-${address}-name`}>Team {':'}</label>
+			<label htmlFor={`robot-${address}-name`}>Team:</label>
 			<input
 				type={'text'}
 				id={`robot-${address}-name`}

--- a/src/components/Admin/RobotTeamAssigner.tsx
+++ b/src/components/Admin/RobotTeamAssigner.tsx
@@ -28,7 +28,7 @@ export const RobotTeamAssigner = () => {
 						)
 						.map(([address, robot]) => (
 							<li key={address}>
-								{shortId(address) + ' '}
+								{shortId(address)}{' '}
 								<RobotTeam
 									address={address}
 									team={robot.team}

--- a/src/components/Admin/RobotTeamAssigner.tsx
+++ b/src/components/Admin/RobotTeamAssigner.tsx
@@ -27,7 +27,7 @@ export const RobotTeamAssigner = () => {
 						)
 						.map(([address, robot]) => (
 							<li key={address}>
-								{address}
+								{address.slice(0, 3) + ' '}
 								<RobotTeam
 									address={address}
 									team={robot.team}
@@ -59,7 +59,7 @@ const RobotTeam = ({
 
 	return (
 		<>
-			<label htmlFor={`robot-${address}-name`}>Team</label>
+			<label htmlFor={`robot-${address}-name`}>Team {':'}</label>
 			<input
 				type={'text'}
 				id={`robot-${address}-name`}

--- a/src/components/Game/Robot.spec.tsx
+++ b/src/components/Game/Robot.spec.tsx
@@ -2,9 +2,10 @@ import { Robot } from 'components/Game/Robot.js'
 import { randomMac } from 'core/test/randomMac.js'
 import { isolateComponent } from 'isolate-react'
 import { randomColor } from 'utils/randomColor.js'
+import { shortId } from 'utils/shortId.js'
 
 describe('Robot', () => {
-	it('should render the 3 first digit of MAC as a label', () => {
+	it('should render the shortId of MAC as a label', () => {
 		const label = randomMac()
 		const robot = isolateComponent(
 			<Robot
@@ -18,7 +19,7 @@ describe('Robot', () => {
 			/>,
 		)
 		expect(robot.findOne('[data-test-id=label]').content()).toContain(
-			label.slice(0, 3),
+			shortId(label),
 		)
 	})
 

--- a/src/components/Game/Robot.spec.tsx
+++ b/src/components/Game/Robot.spec.tsx
@@ -4,7 +4,7 @@ import { isolateComponent } from 'isolate-react'
 import { randomColor } from 'utils/randomColor.js'
 
 describe('Robot', () => {
-	it('should render the MAC as a label', () => {
+	it('should render the 3 first digit of MAC as a label', () => {
 		const label = randomMac()
 		const robot = isolateComponent(
 			<Robot
@@ -17,7 +17,9 @@ describe('Robot', () => {
 				rotationDeg={0}
 			/>,
 		)
-		expect(robot.findOne('[data-test-id=label]').content()).toContain(label)
+		expect(robot.findOne('[data-test-id=label]').content()).toContain(
+			label.slice(0, 3),
+		)
 	})
 
 	it('should render a triangle with the tip facing north', () => {

--- a/src/components/Game/Robot.tsx
+++ b/src/components/Game/Robot.tsx
@@ -1,6 +1,7 @@
 import Color from 'color'
 import styles from 'components/Game/Robot.module.css'
 import { nanoid } from 'nanoid'
+import { shortId } from 'utils/shortId.js'
 
 const getMouseCoordinates = (
 	e: React.MouseEvent<SVGGElement, MouseEvent>,
@@ -165,7 +166,7 @@ export const Robot = ({
 				textAnchor="middle"
 				data-test-id="label"
 			>
-				{id.slice(0, 3)}
+				{shortId(id)}
 			</text>
 		</g>
 	)

--- a/src/components/Game/Robot.tsx
+++ b/src/components/Game/Robot.tsx
@@ -165,7 +165,7 @@ export const Robot = ({
 				textAnchor="middle"
 				data-test-id="label"
 			>
-				{id}
+				{id.slice(0, 3)}
 			</text>
 		</g>
 	)

--- a/src/components/Game/RobotConfig.tsx
+++ b/src/components/Game/RobotConfig.tsx
@@ -1,5 +1,6 @@
 import { Main } from 'components/Main'
 import { useState } from 'react'
+import { shortId } from 'utils/shortId.js'
 
 export const RobotConfig = ({
 	id,
@@ -31,7 +32,7 @@ export const RobotConfig = ({
 						backgroundColor: teamColor,
 					}}
 				>
-					Robot {id.slice(0, 3)}
+					Robot {shortId(id)}
 				</div>
 				<div className="card-body">
 					<fieldset className="mt-1">

--- a/src/components/Game/RobotConfig.tsx
+++ b/src/components/Game/RobotConfig.tsx
@@ -31,7 +31,7 @@ export const RobotConfig = ({
 						backgroundColor: teamColor,
 					}}
 				>
-					Robot {id}
+					Robot {id.slice(0, 3)}
 				</div>
 				<div className="card-body">
 					<fieldset className="mt-1">

--- a/src/utils/shortId.spec.ts
+++ b/src/utils/shortId.spec.ts
@@ -3,10 +3,10 @@ import { shortId } from 'utils/shortId.js'
 describe('shortId()', () => {
 	describe('it should reduce the string input to only the three first characters in the string ', () => {
 		it.each([
-			['Example', 'Exa'],
+			['15e638e5d725', '15e'],
 			['Test', 'Tes'],
 			['robotId', 'rob'],
-			['Hello', 'Hel'],
+			['He', 'He'],
 		])('"%s" -> "%s"', (received, expected) =>
 			expect(shortId(received)).toBe(expected),
 		)

--- a/src/utils/shortId.spec.ts
+++ b/src/utils/shortId.spec.ts
@@ -1,0 +1,14 @@
+import { shortId } from 'utils/shortId.js'
+
+describe('shortId()', () => {
+	describe('it should reduce the string input to only the three first characters in the string ', () => {
+		it.each([
+			['Example', 'Exa'],
+			['Test', 'Tes'],
+			['robotId', 'rob'],
+			['Hello', 'Hel'],
+		])('"%s" -> "%s"', (received, expected) =>
+			expect(shortId(received)).toBe(expected),
+		)
+	})
+})

--- a/src/utils/shortId.ts
+++ b/src/utils/shortId.ts
@@ -1,4 +1,5 @@
-/**This is needed, because we want to reduce the id/MAC-adress displayed for the
+/**
+ * This is needed, because we want to reduce the id/MAC-adress displayed for the
  * robots to a given number that should be equal everywhere
  */
 export const shortId = (id: string): string => id.slice(0, 3)

--- a/src/utils/shortId.ts
+++ b/src/utils/shortId.ts
@@ -1,0 +1,4 @@
+/**This is needed, because we want to reduce the id/MAC-adress displayed for the
+ * robots to a given number that should be equal everywhere
+ */
+export const shortId = (id: string): string => id.slice(0, 3)


### PR DESCRIPTION
Just reduction of the Mac-address displayed to the user, having the whole MAC was quite messy. I assumed that 3 characters would be an ok amount to still distinguish between each of the robots. 